### PR TITLE
hotfix: Geminiのモデルを変更

### DIFF
--- a/apps/api/src/services/google/gemini-api.ts
+++ b/apps/api/src/services/google/gemini-api.ts
@@ -6,7 +6,7 @@ import type { Difficulty } from '../../types';
 
 const API_ENDPOINT_BASE =
   'https://generativelanguage.googleapis.com/v1beta/models';
-const MODEL_NAME = 'gemini-1.5-flash';
+const MODEL_NAME = 'gemini-2.0-flash';
 
 /**
  * Gemini API に投げるプロンプト


### PR DESCRIPTION
## やったこと
Geminiのモデルを `1.5-flash` -> `2.0-flash` に変更した。

## なぜか
`1.5-flash` のモデルが既にサービス終わってそう。
geminiAPIを叩いた時に、404が返ってきてて、調べたらモデルがないとのこと。

ソース：
https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/1-5-flash?hl=ja